### PR TITLE
Remove frivolous and dangerous calls to .retain()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <name>Flow Networking</name>
     <groupId>com.flowpowered</groupId>
     <artifactId>flow-networking</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <inceptionYear>2013</inceptionYear>
     <url>http://flowpowered.com</url>

--- a/src/main/java/com/flowpowered/networking/pipeline/MessageProcessorDecoder.java
+++ b/src/main/java/com/flowpowered/networking/pipeline/MessageProcessorDecoder.java
@@ -42,12 +42,11 @@ public class MessageProcessorDecoder extends ByteToMessageDecoder {
     protected void decode(ChannelHandlerContext ctx, ByteBuf buf, List<Object> frames) throws Exception {
         MessageProcessor processor = getProcessor();
         if (processor == null) {
-            frames.add(buf.readBytes(buf.readableBytes()).retain());
+            frames.add(buf.readBytes(buf.readableBytes()));
             return;
         }
         // Eventually, we will run out of bytes and a ReplayableError will be called
         ByteBuf liveBuffer = ctx.alloc().buffer();
-        liveBuffer.retain();
         liveBuffer = processor.processInbound(ctx, buf, liveBuffer);
         frames.add(liveBuffer);
     }

--- a/src/main/java/com/flowpowered/networking/pipeline/MessageProcessorEncoder.java
+++ b/src/main/java/com/flowpowered/networking/pipeline/MessageProcessorEncoder.java
@@ -23,11 +23,11 @@
  */
 package com.flowpowered.networking.pipeline;
 
-import java.util.List;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
+
+import java.util.List;
 
 import com.flowpowered.networking.processor.MessageProcessor;
 
@@ -45,10 +45,10 @@ public class MessageProcessorEncoder extends MessageToMessageEncoder<ByteBuf> {
     protected void encode(ChannelHandlerContext ctx, final ByteBuf buf, List<Object> out) throws Exception {
         final MessageProcessor processor = getProcessor();
         if (processor == null) {
-            out.add(buf.readBytes(buf.readableBytes()).retain());
+            out.add(buf.readBytes(buf.readableBytes()));
             return;
         }
-        ByteBuf toAdd = ctx.alloc().buffer().retain();
+        ByteBuf toAdd = ctx.alloc().buffer();
         toAdd = processor.processOutbound(ctx, buf, toAdd);
         out.add(toAdd);
     }


### PR DESCRIPTION
Solves issues in downstream Glowstone.

Newly created ByteBufs don't need to have .retain() called, only if you're passing a bytebuf unchanged from one handler to another. That isn't the case in any of the calls, and so there are resource leak problems in implementing projects.

Pom version change is just for ease of testing, you can revert at leisure.
